### PR TITLE
Use prepare instead of postinstall, extract scripts into files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,12 +46,11 @@
     "prettier": "2.7.1"
   },
   "scripts": {
-    "build": "esbuild --bundle --format=esm src/main.ts --outdir=dist --sourcemap",
     "build-storybook": "build-storybook",
-    "clean": "rm -Rf dist",
-    "format": "pnpm prettier --ignore-path .gitignore --write .",
-    "lint": "pnpm eslint --ignore-path .gitignore --ext .jsx --ext .js --ext .jsx --ext .ts --ext .tsx .",
-    "prepare": "pnpm build && if [ -d .git ]; then husky install; fi",
+    "clean": "scripts/clean.sh",
+    "format": "scripts/format.sh",
+    "lint": "scripts/lint.sh",
+    "prepare": "scripts/prepare.sh",
     "storybook": "start-storybook -p 6006"
   },
   "files": [

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+rm -Rf dist

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+pnpm prettier \
+    --ignore-path .gitignore \
+    --write \
+    .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+pnpm eslint \
+    --ignore-path .gitignore \
+    --ext .jsx \
+    --ext .js \
+    --ext .jsx \
+    --ext .ts \
+    --ext .tsx \
+    .

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+pnpm esbuild --bundle --format=esm src/main.ts --outdir=dist --sourcemap
+
+if [ -d .git ];
+then
+    pnpm husky install
+fi


### PR DESCRIPTION
## Overview

1. Move the logic in the `postinstall` script into the `prepare` script.
1. Extracts many of the scripts into their own files.

## Motivation

1. It appears that `npm` (and thus `pnpm`) will not install `devDependencies` before running `postinstall` triggering errors like [this one](https://github.com/InferenceQL/inferenceql.publish/actions/runs/3300498800/jobs/5445056610#step:8:23).
1. Prepare seemed like it was getting complicated enough to warrant being in its own file.