### PR TITLE
fix: Add back missing npm lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
     "typescript": "^4.8.4"
   },
   "scripts": {
+    "clean": "scripts/clean.sh",
+    "format": "scripts/format.sh",
+    "lint": "scripts/lint.sh",
+    "prepare": "scripts/prepare.sh",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
In reinstalling Storybook to get it working, I accidentally removed the lifecycle scripts necessary to compile the Typescript on installation by npm